### PR TITLE
UI improvements

### DIFF
--- a/src/main/java/com/eliteessentials/config/PluginConfig.java
+++ b/src/main/java/com/eliteessentials/config/PluginConfig.java
@@ -24,6 +24,11 @@ public class PluginConfig {
      */
     public boolean advancedPermissions = false;
 
+    // ==================== GUI ====================
+    
+    /** GUI pagination and entry limits */
+    public GuiConfig gui = new GuiConfig();
+
     // ==================== COMMAND CONFIGS ====================
     
     public RtpConfig rtp = new RtpConfig();
@@ -376,12 +381,36 @@ public class PluginConfig {
         messages.put("deathGeneric", "{player} died");
         
         // ==================== GUI LABELS ====================
-        messages.put("guiHomesTitle", "Your Homes ({count}/{max})");
-        messages.put("guiWarpsTitle", "Server Warps");
-        messages.put("guiKitStatusLocked", "[Locked]");
-        messages.put("guiKitStatusClaimed", "Claimed");
-        messages.put("guiKitStatusReady", "Ready");
-        messages.put("guiWarpStatusOpOnly", "[OP Only]");
+        messages.put("gui.HomesTitle", "Your Homes ({count}/{max})");
+        messages.put("gui.WarpsTitle", "Server Warps");
+        messages.put("gui.KitTitle", "Kits");
+        messages.put("gui.TpaTitle", "TPA");
+        messages.put("gui.TpahereTitle", "TPAHERE");
+        messages.put("gui.TpaEmpty", "No other players online.");
+        messages.put("gui.TpaRequestButton", "Request");
+        messages.put("gui.PaginationPrev", "Prev");
+        messages.put("gui.PaginationNext", "Next");
+        messages.put("gui.PaginationLabel", "Page {current} / {total}");
+        messages.put("gui.WarpButton", "Warp");
+        messages.put("gui.WarpDeleteButton", "X");
+        messages.put("gui.WarpDeleteConfirmButton", "?");
+        messages.put("gui.KitClaimButton", "Claim");
+        messages.put("gui.HomeEntryEdit", "Edit");
+        messages.put("gui.HomeEntryGo", "Go");
+        messages.put("gui.HomeEntryWorld", "World: {world} at {coords}");
+        messages.put("gui.HomeEditTitle", "Edit Home");
+        messages.put("gui.HomeEditNameLabel", "Home Name");
+        messages.put("gui.HomeEditNamePlaceholder", "Enter a new name");
+        messages.put("gui.HomeEditCancelButton", "Cancel");
+        messages.put("gui.HomeEditRenameButton", "Rename");
+        messages.put("gui.HomeEditDangerTitle", "Danger Zone");
+        messages.put("gui.HomeEditDangerBody", "Do you want to delete this home?");
+        messages.put("gui.HomeEditDeleteButton", "Delete");
+        messages.put("gui.HomeEditDeleteConfirmButton", "Confirm");
+        messages.put("gui.KitStatusLocked", "[Locked]");
+        messages.put("gui.KitStatusClaimed", "Claimed");
+        messages.put("gui.KitStatusReady", "Ready");
+        messages.put("gui.WarpStatusOpOnly", "[OP Only]");
         
         // ==================== PLAYTIME REWARDS ====================
         messages.put("playTimeRewardReceived", "&a[Reward] &fYou received: &e{reward}");
@@ -452,6 +481,22 @@ public class PluginConfig {
             // Return default range
             return new WorldRtpRange(minRange, maxRange);
         }
+    }
+
+    // ==================== GUI ====================
+    
+    public static class GuiConfig {
+        /** Number of entries shown per page in the TPA/TPAHERE GUI */
+        public int playersPerTpaPage = 8;
+        
+        /** Number of entries shown per page in the Warp GUI */
+        public int warpsPerPage = 8;
+        
+        /** Number of entries shown per page in the Homes GUI */
+        public int homesPerPage = 8;
+        
+        /** Number of entries shown per page in the Kits GUI */
+        public int kitsPerPage = 8;
     }
     
     /**

--- a/src/main/java/com/eliteessentials/gui/HomeEditPage.java
+++ b/src/main/java/com/eliteessentials/gui/HomeEditPage.java
@@ -60,13 +60,24 @@ public class HomeEditPage extends InteractiveCustomUIPage<HomeEditPage.HomeEditD
                       UIEventBuilder eventBuilder, Store<EntityStore> store) {
         commandBuilder.append("Pages/EliteEssentials_HomeEditPage.ui");
 
+        commandBuilder.set("#PageTitleLabel.Text", configManager.getMessage("gui.HomeEditTitle"));
+        commandBuilder.set("#HomeNameLabel.Text", configManager.getMessage("gui.HomeEditNameLabel"));
+        commandBuilder.set("#HomeNameInput.PlaceholderText", configManager.getMessage("gui.HomeEditNamePlaceholder"));
+        commandBuilder.set("#CancelButton.Text", configManager.getMessage("gui.HomeEditCancelButton"));
+        commandBuilder.set("#DoneButton.Text", configManager.getMessage("gui.HomeEditRenameButton"));
+        commandBuilder.set("#DangerZoneLabel.Text", configManager.getMessage("gui.HomeEditDangerTitle"));
+        commandBuilder.set("#DangerZoneInfo.Text", configManager.getMessage("gui.HomeEditDangerBody"));
+
         Optional<Home> homeOpt = homeService.getHome(playerRef.getUuid(), homeName);
         if (homeOpt.isPresent()) {
             String existingName = homeOpt.get().getName();
             pendingNewName = existingName;
             commandBuilder.set("#HomeNameInput.Value", existingName);
         }
-        commandBuilder.set("#DeleteButton.Text", deleteConfirm ? "Confirm" : "Delete");
+        commandBuilder.set("#DeleteButton.Text",
+            deleteConfirm
+                ? configManager.getMessage("gui.HomeEditDeleteConfirmButton")
+                : configManager.getMessage("gui.HomeEditDeleteButton"));
 
         Player playerEntity = store.getComponent(ref, Player.getComponentType());
         if (playerEntity != null) {
@@ -195,7 +206,10 @@ public class HomeEditPage extends InteractiveCustomUIPage<HomeEditPage.HomeEditD
 
     private void updateDeleteButton() {
         UICommandBuilder commandBuilder = new UICommandBuilder();
-        commandBuilder.set("#DeleteButton.Text", deleteConfirm ? "Confirm" : "Delete");
+        commandBuilder.set("#DeleteButton.Text",
+            deleteConfirm
+                ? configManager.getMessage("gui.HomeEditDeleteConfirmButton")
+                : configManager.getMessage("gui.HomeEditDeleteButton"));
         sendUpdate(commandBuilder, false);
     }
 

--- a/src/main/java/com/eliteessentials/gui/components/PaginationControl.java
+++ b/src/main/java/com/eliteessentials/gui/components/PaginationControl.java
@@ -28,15 +28,42 @@ public final class PaginationControl {
         );
     }
 
-    public static void update(UICommandBuilder commandBuilder, String rootSelector, int pageIndex, int totalPages) {
-        commandBuilder.set(rootSelector + " #PageLabel.Text", "Page " + (pageIndex + 1) + " / " + totalPages);
+    public static void update(UICommandBuilder commandBuilder, String rootSelector, int pageIndex, int totalPages, String labelFormat) {
+        commandBuilder.set(rootSelector + " #PageLabel.Text", formatLabel(labelFormat, pageIndex + 1, totalPages));
         commandBuilder.set(rootSelector + " #PrevButton.Disabled", pageIndex <= 0);
         commandBuilder.set(rootSelector + " #NextButton.Disabled", pageIndex >= totalPages - 1);
     }
 
-    public static void setEmpty(UICommandBuilder commandBuilder, String rootSelector) {
-        commandBuilder.set(rootSelector + " #PageLabel.Text", "Page 0 / 0");
+    public static void setEmpty(UICommandBuilder commandBuilder, String rootSelector, String labelFormat) {
+        commandBuilder.set(rootSelector + " #PageLabel.Text", formatLabel(labelFormat, 0, 0));
         commandBuilder.set(rootSelector + " #PrevButton.Disabled", true);
         commandBuilder.set(rootSelector + " #NextButton.Disabled", true);
+    }
+
+    public static void updateOrHide(UICommandBuilder commandBuilder, String rootSelector, int pageIndex, int totalPages, String labelFormat) {
+        if (totalPages <= 1) {
+            commandBuilder.set(rootSelector + ".Visible", false);
+            return;
+        }
+        commandBuilder.set(rootSelector + ".Visible", true);
+        update(commandBuilder, rootSelector, pageIndex, totalPages, labelFormat);
+    }
+
+    public static void setEmptyAndHide(UICommandBuilder commandBuilder, String rootSelector, String labelFormat) {
+        setEmpty(commandBuilder, rootSelector, labelFormat);
+        commandBuilder.set(rootSelector + ".Visible", false);
+    }
+
+    public static void setButtonLabels(UICommandBuilder commandBuilder, String rootSelector, String prevText, String nextText) {
+        commandBuilder.set(rootSelector + " #PrevButton.Text", prevText);
+        commandBuilder.set(rootSelector + " #NextButton.Text", nextText);
+    }
+
+    private static String formatLabel(String labelFormat, int current, int total) {
+        String format = (labelFormat == null || labelFormat.isBlank())
+            ? "Page {current} / {total}"
+            : labelFormat;
+        return format.replace("{current}", String.valueOf(current))
+                     .replace("{total}", String.valueOf(total));
     }
 }

--- a/src/main/resources/Common/UI/Custom/Pages/EliteEssentials_DeleteConfirm.ui
+++ b/src/main/resources/Common/UI/Custom/Pages/EliteEssentials_DeleteConfirm.ui
@@ -1,6 +1,0 @@
-$C = "../Common.ui";
-
-$C.@CancelTextButton #DeleteButton {
-  Anchor: (Left: 0, Right: 0, Top: 0, Bottom: 0);
-  Text: "Delete";
-}

--- a/src/main/resources/Common/UI/Custom/Pages/EliteEssentials_HomeEditPage.ui
+++ b/src/main/resources/Common/UI/Custom/Pages/EliteEssentials_HomeEditPage.ui
@@ -1,17 +1,16 @@
 $C = "../Common.ui";
+$E = "EliteEssentials_Shared.ui";
 
 $C.@PageOverlay {
   LayoutMode: Middle;
 
   $C.@Container {
-    Anchor: (Width: 580, Height: 300);
+    Anchor: (Width: 580, Height: 270);
 
     #Title {
       Group {
-        Label #TitleText {
-          Anchor: (Height: 28);
-          Style: (...$C.@TitleStyle, HorizontalAlignment: Center);
-          Text: "Edit Home";
+        $E.@EEPageTitle {
+          @Text = "Edit Home";
         }
       }
     }
@@ -24,7 +23,7 @@ $C.@PageOverlay {
         LayoutMode: Top;
         Anchor: (Bottom: 8);
 
-        Label {
+        Label #HomeNameLabel {
           Anchor: (Bottom: 6);
           Style: $C.@SubtitleStyle;
           Text: "Home Name";
@@ -38,17 +37,17 @@ $C.@PageOverlay {
 
       Group {
         LayoutMode: Left;
-        Anchor: (Height: 44, Bottom: 10);
+        Anchor: (Height: 32, Bottom: 10);
 
         Group { FlexWeight: 1; }
 
-        $C.@SecondaryTextButton #CancelButton {
-          @Anchor = (Width: 130, Right: 8);
+        $C.@SmallSecondaryTextButton #CancelButton {
+          @Anchor = (Width: 100, Right: 8);
           Text: "Cancel";
         }
 
-        $C.@TextButton #DoneButton {
-          @Anchor = (Width: 130);
+        $E.@EEPrimarySmallTextButton #DoneButton {
+          @Anchor = (Width: 110);
           Text: "Rename";
         }
       }
@@ -61,13 +60,13 @@ $C.@PageOverlay {
         LayoutMode: Top;
         Anchor: (Bottom: 0);
 
-        Label {
+        Label #DangerZoneLabel {
           Anchor: (Bottom: 2);
           Style: $C.@SubtitleStyle;
           Text: "Danger Zone";
         }
 
-        Label {
+        Label #DangerZoneInfo {
           Anchor: (Bottom: 6);
           Style: (
             FontSize: 11,
@@ -78,10 +77,10 @@ $C.@PageOverlay {
 
         Group {
           LayoutMode: Left;
-          Anchor: (Height: 44);
+          Anchor: (Height: 32);
 
-          $C.@CancelTextButton #DeleteButton {
-            @Anchor = (Width: 140);
+          $E.@EECancelSmallTextButton #DeleteButton {
+            @Anchor = (Width: 110);
             Text: "Delete";
           }
         }

--- a/src/main/resources/Common/UI/Custom/Pages/EliteEssentials_HomeEntry.ui
+++ b/src/main/resources/Common/UI/Custom/Pages/EliteEssentials_HomeEntry.ui
@@ -1,4 +1,5 @@
 $C = "../Common.ui";
+$E = "EliteEssentials_Shared.ui";
 
 Group {
   LayoutMode: Left;
@@ -36,15 +37,15 @@ Group {
 
   Group #HomeActions {
     LayoutMode: Right;
-    Anchor: (Right: 0, Width: 210);
+    Anchor: (Right: 0, Width: 190);
 
-    $C.@SecondaryTextButton #HomeEditButton {
-      @Anchor = (Width: 90, Right: 8);
+    $C.@SmallSecondaryTextButton #HomeEditButton {
+      @Anchor = (Width: 70, Right: 8);
       Text: "Edit";
     }
 
-    $C.@TextButton #HomeTeleportButton {
-      @Anchor = (Width: 110, Right: 8);
+    $E.@EEPrimarySmallTextButton #HomeTeleportButton {
+      @Anchor = (Width: 60);
       Text: "Go";
     }
   }

--- a/src/main/resources/Common/UI/Custom/Pages/EliteEssentials_HomePage.ui
+++ b/src/main/resources/Common/UI/Custom/Pages/EliteEssentials_HomePage.ui
@@ -1,47 +1,36 @@
 $C = "../Common.ui";
+$E = "EliteEssentials_Shared.ui";
 
 $C.@PageOverlay {
   LayoutMode: Middle;
   $C.@Container {
-    Anchor: (Width: 580, Height: 400);
+    Anchor: (Width: 580, Height: 420);
 
     #Title {
       Group {
-        Anchor: (Height: 50);
-
-        Label #TitleLabel {
-          Style: (
-            FontSize: 24,
-            LetterSpacing: 2,
-            RenderUppercase: true,
-            RenderBold: true,
-            TextColor: #ccb588,
-            HorizontalAlignment: Center,
-            VerticalAlignment: Center
-          );
-          Padding: (Top: 3);
-          Text: "Your Homes";
+        $E.@EEPageTitle {
+          @Text = "Your Homes";
         }
       }
     }
 
     #Content {
-      LayoutMode: Left;
+      LayoutMode: Top;
 
-      Group #Main {
-        LayoutMode: Top;
+      Group #HomeList {
+        FlexWeight: 1;
+        LayoutMode: TopScrolling;
+        Padding: (Left: 4);
+        ScrollbarStyle: $C.@DefaultScrollbarStyle;
 
-        Group #HomeList {
-          Anchor: (Width: 560);
-          FlexWeight: 1;
-          LayoutMode: TopScrolling;
-          Padding: (Left: 4);
-          ScrollbarStyle: $C.@DefaultScrollbarStyle;
-
-          Group #HomeCards {
-            LayoutMode: Top;
-          }
+        Group #HomeCards {
+          LayoutMode: Top;
         }
+      }
+
+      Group #Pagination {
+        LayoutMode: Left;
+        Anchor: (Top: 10, Left: 0, Right: 0);
       }
     }
   }

--- a/src/main/resources/Common/UI/Custom/Pages/EliteEssentials_KitEntry.ui
+++ b/src/main/resources/Common/UI/Custom/Pages/EliteEssentials_KitEntry.ui
@@ -1,4 +1,5 @@
 $C = "../Common.ui";
+$E = "EliteEssentials_Shared.ui";
 
 Group {
   LayoutMode: Left;
@@ -44,10 +45,10 @@ Group {
 
   Group #KitActions {
     LayoutMode: Right;
-    Anchor: (Right: 0, Width: 140);
+    Anchor: (Right: 0, Width: 110);
 
-    $C.@TextButton #KitClaimButton {
-      @Anchor = (Width: 120);
+    $E.@EEPrimarySmallTextButton #KitClaimButton {
+      @Anchor = (Width: 90);
       Text: "Claim";
     }
   }

--- a/src/main/resources/Common/UI/Custom/Pages/EliteEssentials_KitPage.ui
+++ b/src/main/resources/Common/UI/Custom/Pages/EliteEssentials_KitPage.ui
@@ -1,35 +1,36 @@
 $C = "../Common.ui";
+$E = "EliteEssentials_Shared.ui";
 
 $C.@PageOverlay {
   LayoutMode: Middle;
   $C.@Container {
-    Anchor: (Width: 580, Height: 400);
+    Anchor: (Width: 580, Height: 420);
 
     #Title {
       Group {
-        $C.@Title {
-          @Text = "EliteEssentials Kits";
+        $E.@EEPageTitle {
+          @Text = "Kits";
         }
       }
     }
 
     #Content {
-      LayoutMode: Left;
+      LayoutMode: Top;
 
-      Group #Main {
-        LayoutMode: Top;
+      Group #KitList {
+        FlexWeight: 1;
+        LayoutMode: TopScrolling;
+        Padding: (Left: 4);
+        ScrollbarStyle: $C.@DefaultScrollbarStyle;
 
-        Group #KitList {
-          Anchor: (Width: 560);
-          FlexWeight: 1;
-          LayoutMode: TopScrolling;
-          Padding: (Left: 4);
-          ScrollbarStyle: $C.@DefaultScrollbarStyle;
-
-          Group #KitCards {
-            LayoutMode: Top;
-          }
+        Group #KitCards {
+          LayoutMode: Top;
         }
+      }
+
+      Group #Pagination {
+        LayoutMode: Left;
+        Anchor: (Top: 10, Left: 0, Right: 0);
       }
     }
   }

--- a/src/main/resources/Common/UI/Custom/Pages/EliteEssentials_Pagination.ui
+++ b/src/main/resources/Common/UI/Custom/Pages/EliteEssentials_Pagination.ui
@@ -8,7 +8,7 @@ Group {
   Group { FlexWeight: 1; }
 
   $C.@SmallSecondaryTextButton #PrevButton {
-    @Anchor = (Width: 90, Height: 28, Right: 10);
+    @Anchor = (Width: 70, Height: 32, Right: 10);
     Text: "Prev";
   }
 
@@ -24,7 +24,7 @@ Group {
   }
 
   $C.@SmallSecondaryTextButton #NextButton {
-    @Anchor = (Width: 90, Height: 28);
+    @Anchor = (Width: 70, Height: 32);
     Text: "Next";
   }
 

--- a/src/main/resources/Common/UI/Custom/Pages/EliteEssentials_Shared.ui
+++ b/src/main/resources/Common/UI/Custom/Pages/EliteEssentials_Shared.ui
@@ -1,0 +1,72 @@
+$C = "../Common.ui";
+
+@SmallButtonHeight = 32;
+@SmallButtonPadding = 16;
+
+@EEPageTitleLabelStyle = LabelStyle(
+  FontSize: 24,
+  LetterSpacing: 2,
+  RenderUppercase: true,
+  RenderBold: true,
+  TextColor: #ccb588,
+  HorizontalAlignment: Center,
+  VerticalAlignment: Center
+);
+
+@EEPageTitle = Group {
+  @Text = "";
+
+  Anchor: (Height: 50);
+
+  Label #PageTitleLabel {
+    Style: @EEPageTitleLabelStyle;
+    Padding: (Top: 3);
+    Text: @Text;
+  }
+};
+
+@EEPrimarySmallTextButtonStyle = TextButtonStyle(
+  Default: (Background: $C.@DefaultSquareButtonDefaultBackground, LabelStyle: $C.@SmallButtonLabelStyle),
+  Hovered: (Background: $C.@DefaultSquareButtonHoveredBackground, LabelStyle: $C.@SmallButtonLabelStyle),
+  Pressed: (Background: $C.@DefaultSquareButtonPressedBackground, LabelStyle: $C.@SmallButtonLabelStyle),
+  Disabled: (Background: $C.@DefaultSquareButtonDisabledBackground, LabelStyle: $C.@SmallButtonDisabledLabelStyle),
+  Sounds: $C.@ButtonSounds,
+);
+
+@EECancelSmallTextButtonStyle = TextButtonStyle(
+  Default: (Background: $C.@CancelTextButtonStyle.Default.Background, LabelStyle: $C.@SmallButtonLabelStyle),
+  Hovered: (Background: $C.@CancelTextButtonStyle.Hovered.Background, LabelStyle: $C.@SmallButtonLabelStyle),
+  Pressed: (Background: $C.@CancelTextButtonStyle.Pressed.Background, LabelStyle: $C.@SmallButtonLabelStyle),
+  Disabled: (Background: $C.@CancelTextButtonStyle.Disabled.Background, LabelStyle: $C.@SmallButtonDisabledLabelStyle),
+  Sounds: $C.@ButtonsCancel,
+);
+
+@EEPrimarySmallTextButton = TextButton {
+  @Anchor = Anchor();
+  @Sounds = ();
+  Style: (
+    ...@EEPrimarySmallTextButtonStyle,
+    Sounds: (
+      ...$C.@ButtonSounds,
+      ...@Sounds
+    )
+  );
+  Anchor: (...@Anchor, Height: @SmallButtonHeight);
+  Padding: (Horizontal: @SmallButtonPadding);
+  Text: @Text;
+};
+
+@EECancelSmallTextButton = TextButton {
+  @Anchor = Anchor();
+  @Sounds = ();
+  Style: (
+    ...@EECancelSmallTextButtonStyle,
+    Sounds: (
+      ...$C.@ButtonSounds,
+      ...@Sounds
+    )
+  );
+  Anchor: (...@Anchor, Height: @SmallButtonHeight);
+  Padding: (Horizontal: @SmallButtonPadding);
+  Text: @Text;
+};

--- a/src/main/resources/Common/UI/Custom/Pages/EliteEssentials_TpaEntry.ui
+++ b/src/main/resources/Common/UI/Custom/Pages/EliteEssentials_TpaEntry.ui
@@ -1,4 +1,5 @@
 $C = "../Common.ui";
+$E = "EliteEssentials_Shared.ui";
 
 Group {
   LayoutMode: Left;
@@ -20,11 +21,11 @@ Group {
 
   Group #PlayerActions {
     LayoutMode: Right;
-    Anchor: (Right: 0, Width: 140);
+    Anchor: (Right: 0, Width: 100);
 
-    $C.@TextButton #PlayerActionButton {
-      @Anchor = (Width: 140);
-      Text: "TPA";
+    $E.@EEPrimarySmallTextButton #PlayerActionButton {
+      @Anchor = (Width: 100);
+      Text: "Request";
     }
   }
 }

--- a/src/main/resources/Common/UI/Custom/Pages/EliteEssentials_TpaPage.ui
+++ b/src/main/resources/Common/UI/Custom/Pages/EliteEssentials_TpaPage.ui
@@ -1,4 +1,5 @@
 $C = "../Common.ui";
+$E = "EliteEssentials_Shared.ui";
 
 $C.@PageOverlay {
   LayoutMode: Middle;
@@ -7,7 +8,7 @@ $C.@PageOverlay {
 
     #Title {
       Group {
-        $C.@Title #PageTitle {
+        $E.@EEPageTitle #PageTitle {
           @Text = "TPA";
         }
 

--- a/src/main/resources/Common/UI/Custom/Pages/EliteEssentials_WarpEntry.ui
+++ b/src/main/resources/Common/UI/Custom/Pages/EliteEssentials_WarpEntry.ui
@@ -1,4 +1,5 @@
 $C = "../Common.ui";
+$E = "EliteEssentials_Shared.ui";
 
 Group {
   LayoutMode: Left;
@@ -44,14 +45,19 @@ Group {
 
   Group #WarpActions {
     LayoutMode: Right;
-    Anchor: (Right: 0, Width: 180);
+    Anchor: (Right: 0, Width: 140);
 
     Group #DeleteButtonSlot {
-      Anchor: (Width: 40, Height: 44, Right: 8);
+      Anchor: (Width: 40, Height: 32, Right: 8);
+
+      $E.@EECancelSmallTextButton #DeleteButton {
+        @Anchor = (Width: 40, Height: 32);
+        Text: "X";
+      }
     }
 
-    $C.@TextButton #WarpButton {
-      @Anchor = (Width: 120, Height: 44);
+    $E.@EEPrimarySmallTextButton #WarpButton {
+      @Anchor = (Width: 90);
       Text: "Warp";
     }
   }

--- a/src/main/resources/Common/UI/Custom/Pages/EliteEssentials_WarpEntryNoDelete.ui
+++ b/src/main/resources/Common/UI/Custom/Pages/EliteEssentials_WarpEntryNoDelete.ui
@@ -1,4 +1,5 @@
 $C = "../Common.ui";
+$E = "EliteEssentials_Shared.ui";
 
 Group {
   LayoutMode: Left;
@@ -36,10 +37,10 @@ Group {
 
   Group #WarpActions {
     LayoutMode: Right;
-    Anchor: (Right: 0, Width: 130);
+    Anchor: (Right: 0, Width: 110);
 
-    $C.@TextButton #WarpButton {
-      @Anchor = (Width: 120, Height: 44);
+    $E.@EEPrimarySmallTextButton #WarpButton {
+      @Anchor = (Width: 90);
       Text: "Warp";
     }
   }

--- a/src/main/resources/Common/UI/Custom/Pages/EliteEssentials_WarpPage.ui
+++ b/src/main/resources/Common/UI/Custom/Pages/EliteEssentials_WarpPage.ui
@@ -1,47 +1,36 @@
 $C = "../Common.ui";
+$E = "EliteEssentials_Shared.ui";
 
 $C.@PageOverlay {
   LayoutMode: Middle;
   $C.@Container {
-    Anchor: (Width: 580, Height: 400);
+    Anchor: (Width: 580, Height: 420);
 
     #Title {
       Group {
-        Anchor: (Height: 50);
-
-        Label #TitleLabel {
-          Style: (
-            FontSize: 24,
-            LetterSpacing: 2,
-            RenderUppercase: true,
-            RenderBold: true,
-            TextColor: #ccb588,
-            HorizontalAlignment: Center,
-            VerticalAlignment: Center
-          );
-          Padding: (Top: 3);
-          Text: "Server Warps";
+        $E.@EEPageTitle {
+          @Text = "Server Warps";
         }
       }
     }
 
     #Content {
-      LayoutMode: Left;
+      LayoutMode: Top;
 
-      Group #Main {
-        LayoutMode: Top;
+      Group #WarpList {
+        FlexWeight: 1;
+        LayoutMode: TopScrolling;
+        Padding: (Left: 4);
+        ScrollbarStyle: $C.@DefaultScrollbarStyle;
 
-        Group #WarpList {
-          Anchor: (Width: 560);
-          FlexWeight: 1;
-          LayoutMode: TopScrolling;
-          Padding: (Left: 4);
-          ScrollbarStyle: $C.@DefaultScrollbarStyle;
-
-          Group #WarpCards {
-            LayoutMode: Top;
-          }
+        Group #WarpCards {
+          LayoutMode: Top;
         }
+      }
+
+      Group #Pagination {
+        LayoutMode: Left;
+        Anchor: (Top: 10, Left: 0, Right: 0);
       }
     }
   }

--- a/src/main/resources/config.json
+++ b/src/main/resources/config.json
@@ -4,6 +4,13 @@
   
   "debug": false,
   "advancedPermissions": false,
+
+  "gui": {
+    "playersPerTpaPage": 8,
+    "warpsPerPage": 8,
+    "homesPerPage": 8,
+    "kitsPerPage": 8
+  },
   
   "rtp": {
     "enabled": true,


### PR DESCRIPTION
## General UI changes
- Added a new UI file `EliteEssentials_Shared.ui` containing shared "small" button presets (primary + cancel/delete) and shared page title styling
  - Removed `EliteEssentials_DeleteConfirm.ui` and moved delete confirmation logic into the shared/entry components
- All UI pages now use custom "small" buttons variants
- Standardized page titles across Home, HomeEdit, Kit, TPA, TPAHERE, and Warp UIs
- Updated TPA/TPAHere UI page to show the executor (yourself) if `debug` is set to `true` in config.json. No real reason behind adding this, was just curious whether players are being correctly listed in the UI lol

## Pagination
- Added pagination to Home, Warp, and Kit pages
- Centralized pagination behavior in PaginationControl (dynamic show/hide, labels, and empty states):
  - Added "GUI" config section with options `playersPerTpaPage`, `warpsPerPage`, `homesPerPage` and `kitsPerPage` (all defaulting to `8`)
  - If some UI pages has less entries than the defined "PerPage" option, the pagination is automatically hidden. For example, if `gui.homesPerPage` in config.sjon is set to `8`, and the player has `<=8` homes, they won't see the pagination on `/home` at all. Was aiming for a UI cleaner look with this

## Messages
- Made all GUI strings configurable via messages.json under the `gui` section.
- Due to game limitations, some messages might not fit into button labels and will get cut off. Again, this is a Hytale limitation, as button labels aren't meant to be responsive. Each button has a fixed hardcoded width and we can't do much about this (not that I'm aware of anyways)

Below I have also provided a test jar with these changes
[EliteEssentials-1.1.6-dev.zip](https://github.com/user-attachments/files/24971193/EliteEssentials-1.1.6-dev.zip)