### PR TITLE
Add persist true to papi expansion

### DIFF
--- a/src/main/java/com/eliteessentials/integration/papi/EliteEssentialsExpansion.java
+++ b/src/main/java/com/eliteessentials/integration/papi/EliteEssentialsExpansion.java
@@ -52,6 +52,11 @@ public class EliteEssentialsExpansion extends PlaceholderExpansion {
     }
 
     @Override
+    public boolean persist() {
+        return true;
+    }
+
+    @Override
     public @Nullable String onPlaceholderRequest(final PlayerRef playerRef, @NotNull final String input) {
         final HomeService homes = main.getHomeService();
         final KitService kits = main.getKitService();


### PR DESCRIPTION
Forgot to add this before, apologies. Without this the expansion still works however if someone runs /papi reload, the expansion will unload and won't automatically reload. This ensures the expansion persists through /papi reload.

Apologies again, should've remembered to add this I know you've already published the update now.