### PR TITLE
Fix /kit cooldown bypass when PlayerReadyEvent doesn't fire at join

### DIFF
--- a/src/main/java/com/eliteessentials/commands/hytale/HytaleKitCommand.java
+++ b/src/main/java/com/eliteessentials/commands/hytale/HytaleKitCommand.java
@@ -76,6 +76,12 @@ public class HytaleKitCommand extends AbstractPlayerCommand {
                           @Nonnull PlayerRef player, @Nonnull World world) {
         UUID playerId = player.getUuid();
         
+        // Self-heal: ensure a PlayerFile exists before any kit operation. Prevents the
+        // infinite-kit exploit where a player whose PlayerReadyEvent never fired (observed
+        // on abnormally slow logins) has no PlayerFile, causing all KitService reads to
+        // return 0 (no cooldown) and writes to silently no-op.
+        kitService.ensurePlayerFile(playerId, player.getUsername());
+        
         if (WorldBlacklistUtil.isWorldBlacklisted(world.getName(), configManager.getConfig().kits.blacklistedWorlds)) {
             ctx.sendMessage(MessageFormatter.formatWithFallback(
                 configManager.getMessage("commandBlacklistedWorld"), "#FF5555"));
@@ -150,6 +156,9 @@ public class HytaleKitCommand extends AbstractPlayerCommand {
     public static void claimKit(CommandContext ctx, Store<EntityStore> store, Ref<EntityStore> ref,
                                 PlayerRef player, String kitName, KitService kitService, ConfigManager configManager) {
         UUID playerId = player.getUuid();
+        
+        // Self-heal: ensure a PlayerFile exists before any kit operation. See note in execute().
+        kitService.ensurePlayerFile(playerId, player.getUsername());
         
         // Get the kit
         Kit kit = kitService.getKit(kitName);

--- a/src/main/java/com/eliteessentials/gui/KitSelectionPage.java
+++ b/src/main/java/com/eliteessentials/gui/KitSelectionPage.java
@@ -89,6 +89,13 @@ public class KitSelectionPage extends InteractiveCustomUIPage<KitSelectionPage.K
         }
 
         UUID playerId = playerRef.getUuid();
+        
+        // Self-heal: ensure a PlayerFile exists before any kit operation. Prevents the
+        // infinite-kit exploit where a player whose PlayerReadyEvent never fired (observed
+        // on abnormally slow logins) has no PlayerFile, causing KitService reads to return
+        // 0 (no cooldown) and writes to silently no-op. Mirrors the guard in HytaleKitCommand.
+        kitService.ensurePlayerFile(playerId, playerRef.getUsername());
+        
         Kit kit = kitService.getKit(data.kit);
         
         if (kit == null) {
@@ -313,6 +320,11 @@ public class KitSelectionPage extends InteractiveCustomUIPage<KitSelectionPage.K
     private void buildKitList(UICommandBuilder commandBuilder, UIEventBuilder eventBuilder) {
         List<Kit> allKits = new ArrayList<>(kitService.getAllKits());
         UUID playerId = playerRef.getUuid();
+        
+        // Self-heal before display-side storage reads, so hasClaimedOnetime / getRemainingCooldown
+        // don't hit the fail-closed paths (which would incorrectly show "Claimed" or a full
+        // cooldown for a legitimate player who simply has no PlayerFile yet).
+        kitService.ensurePlayerFile(playerId, playerRef.getUsername());
         
         if (allKits.isEmpty()) {
             commandBuilder.clear("#KitCards");

--- a/src/main/java/com/eliteessentials/services/KitService.java
+++ b/src/main/java/com/eliteessentials/services/KitService.java
@@ -44,6 +44,49 @@ public class KitService {
     }
 
     /**
+     * Ensure a PlayerFile exists (create + cache + persist if missing) for the given player.
+     *
+     * This is a self-heal path for the case where {@code PlayerReadyEvent} never fired for the
+     * player (observed in practice when a player's initial login is abnormally slow, e.g. a
+     * previous handshake timeout plus a long anti-cheat registration). Without this, every
+     * KitService read/write silently no-ops because {@code getPlayer(UUID)} returns null for
+     * players who are neither cached nor on disk — which previously allowed infinite /kit
+     * usage with no cooldown recorded.
+     *
+     * Callers should invoke this at every kit entry point (command handler, NPC, GUI) before
+     * any cooldown / onetime lookup.
+     *
+     * @return true if the PlayerFile exists or was created; false if storage is unavailable.
+     */
+    public boolean ensurePlayerFile(UUID playerId, String playerName) {
+        if (playerFileStorage == null) {
+            logger.warning("[Kit] ensurePlayerFile: storage is null, cannot ensure PlayerFile for " + playerId);
+            return false;
+        }
+
+        // Fast path: already cached or on disk.
+        PlayerFile existing = playerFileStorage.getPlayer(playerId);
+        if (existing != null) {
+            return true;
+        }
+
+        // Slow path: the 2-arg overload creates + caches + indexes + marks dirty. We then
+        // force an immediate save so the file survives a crash/restart even if no further
+        // operations mark it dirty. This mirrors what PlayerService.onPlayerJoin does for
+        // new players.
+        PlayerFile created = playerFileStorage.getPlayer(playerId, playerName);
+        if (created == null) {
+            logger.warning("[Kit] ensurePlayerFile: failed to create PlayerFile for " + playerName + " (" + playerId + ")");
+            return false;
+        }
+
+        playerFileStorage.saveAndMarkDirty(playerId);
+        logger.warning("[Kit] Self-healed missing PlayerFile for " + playerName + " (" + playerId
+            + "). This usually means PlayerReadyEvent did not fire for this player at initial join.");
+        return true;
+    }
+
+    /**
      * Load kits from kits.json
      */
     public void loadKits() {
@@ -157,7 +200,14 @@ public class KitService {
         
         PlayerFile playerFile = playerFileStorage.getPlayer(playerId);
         if (playerFile == null) {
-            return 0;
+            // Fail closed: if we cannot read cooldown state, assume the player is still on cooldown.
+            // Previously this returned 0, which allowed infinite kit claims when PlayerReadyEvent
+            // failed to fire at player join (no PlayerFile existed anywhere). Callers should use
+            // ensurePlayerFile() before this path; this branch is defense-in-depth.
+            logger.warning("[Kit] PlayerFile missing for " + playerId
+                + " on cooldown check for kit '" + kitId
+                + "' — treating as on cooldown (fail-closed).");
+            return effectiveCooldown;
         }
 
         long lastUsed = playerFile.getKitLastUsed(kitId);
@@ -188,7 +238,13 @@ public class KitService {
         if (playerFileStorage == null) return;
         
         PlayerFile playerFile = playerFileStorage.getPlayer(playerId);
-        if (playerFile == null) return;
+        if (playerFile == null) {
+            // Defense-in-depth: log rather than silently lose the cooldown write.
+            // Callers should ensurePlayerFile() before this path.
+            logger.warning("[Kit] Cannot record cooldown for kit '" + kitId
+                + "' for " + playerId + ": PlayerFile missing (callers should ensurePlayerFile first).");
+            return;
+        }
         
         playerFile.setKitUsed(kitId);
         playerFileStorage.saveAndMarkDirty(playerId);
@@ -221,7 +277,15 @@ public class KitService {
         if (playerFileStorage == null) return false;
         
         PlayerFile playerFile = playerFileStorage.getPlayer(playerId);
-        if (playerFile == null) return false;
+        if (playerFile == null) {
+            // Fail closed: if we cannot read claim state, assume already claimed so we don't
+            // hand out one-time kits (e.g. starter) repeatedly. Callers should ensurePlayerFile()
+            // before this path; when they do, a freshly-created PlayerFile has no claims recorded
+            // and this branch is not reached, so legitimate new players still get their kit.
+            logger.warning("[Kit] hasClaimedOnetime: PlayerFile missing for " + playerId
+                + ", kit '" + kitId + "' — treating as claimed (fail-closed).");
+            return true;
+        }
         
         boolean hasClaimed = playerFile.hasClaimedKit(kitId);
         
@@ -256,7 +320,13 @@ public class KitService {
         }
         
         PlayerFile playerFile = playerFileStorage.getPlayer(playerId);
-        if (playerFile == null) return;
+        if (playerFile == null) {
+            // Defense-in-depth: log rather than silently lose the claim write. Callers should
+            // ensurePlayerFile() before this path.
+            logger.warning("[Kit] Cannot record one-time claim for kit '" + kitId
+                + "' for " + playerId + ": PlayerFile missing (callers should ensurePlayerFile first).");
+            return;
+        }
         
         playerFile.claimKit(kitId);
         playerFileStorage.saveAndMarkDirty(playerId);

--- a/src/main/java/com/eliteessentials/storage/PlayerFileStorage.java
+++ b/src/main/java/com/eliteessentials/storage/PlayerFileStorage.java
@@ -155,6 +155,13 @@ public class PlayerFileStorage implements PlayerStorageProvider {
     public void savePlayer(UUID uuid) {
         PlayerFile data = cache.get(uuid);
         if (data == null) {
+            // Historically this silently returned, which hid bugs where callers marked a
+            // player dirty without the file ever being loaded into cache (e.g. KitService
+            // writes for a player whose PlayerReadyEvent never fired). Log a warning so
+            // such cases are visible; callers should ensure the PlayerFile is cached first.
+            logger.warning("[PlayerFileStorage] savePlayer called for uncached UUID " + uuid
+                + " — save skipped. A caller tried to persist a player that was never loaded; "
+                + "this usually means KitService (or similar) ran before the PlayerFile existed.");
             return;
         }
         


### PR DESCRIPTION
## Summary

Fixes an exploit where a player can claim `/kit` repeatedly with no cooldown if their `PlayerReadyEvent` fails to fire during initial join. Observed in production with a real player; reproduced from logs.

## Root cause

When `PlayerReadyEvent` doesn't fire for a player, `JoinQuitListener.onPlayerJoin` never runs, so `PlayerService.onPlayerJoin` never creates a `PlayerFile`. Every subsequent `KitService` call then silently no-ops:

- `getRemainingCooldown` → `playerFileStorage.getPlayer(uuid)` returns `null` (no cache, no disk file) → method returns `0` → **no cooldown enforced**
- `setKitUsed` / `setOnetimeClaimed` → same null check → **silent return, nothing persisted**
- Next `/kit` call repeats the cycle indefinitely

After a server restart the cache is cleared and there's still no disk file, so `isFirstJoin` evaluates `true` again and the player is "welcomed" a second time — which is how I noticed something was off.

## Why PlayerReadyEvent doesn't fire

Upstream Hytale issue — observed when the initial login handshake times out and the retry has an abnormally slow anti-cheat registration phase. In the affected log, `[Universe|P] Adding player` fired at 12:17:42 but `[EliteEssentials] PlayerReadyEvent for:` did not fire until 12:53:34 (36 minutes later, on a world change). Every other player in the same log had this gap at 2–7 seconds. Worth a separate upstream report; this PR makes EE resilient to it regardless.

## Fix

Three layers, all defensive:

### 1. `KitService` — `ensurePlayerFile` helper + fail-closed reads

New `ensurePlayerFile(UUID, String)` method that creates + caches + persists a `PlayerFile` if one doesn't exist. Uses the existing 2-arg `PlayerStorageProvider.getPlayer(uuid, name)` overload which is already on the interface, so it works for both `PlayerFileStorage` and `SqlPlayerStorage` backends.

Fail-closed in `getRemainingCooldown` (returns full effective cooldown) and `hasClaimedOnetime` (returns `true`) when `PlayerFile` is missing — so any future edge case where this helper isn't called surfaces as "player reports they can't use /kit" instead of "silent infinite-kit exploit." Log warnings replace silent returns in `setKitUsed` and `setOnetimeClaimed`.

### 2. `PlayerFileStorage.savePlayer` — log uncached-UUID skip

The silent no-op in `savePlayer` when a player isn't cached is how this bug went undetected for weeks. Now logs a warning so similar issues are visible in operations.

### 3. `HytaleKitCommand` + `KitSelectionPage` — self-heal at every kit entry point

`ensurePlayerFile` is called at:
- `HytaleKitCommand.execute` (GUI-open path for `/kit`)
- `HytaleKitCommand.claimKit` static (handles `/kit <name>` and any external/NPC callers)
- `KitSelectionPage.handleDataEvent` (GUI claim path)
- `KitSelectionPage.buildKitList` (GUI display path — prevents incorrect "Claimed"/full-cooldown display)

## Safety — does this block legitimate players?

No. The `ensurePlayerFile` fast path hits for veteran players (file on disk) and normal-join new players (file created by `PlayerService.onPlayerJoin`). The slow-path creation runs only for the `_0x_`-style case where the file genuinely doesn't exist anywhere, and creates a fresh `PlayerFile` with no claims and zero cooldowns — so legitimate new players still get their starter kit and first daily.

Fail-closed branches activate only when `playerFileStorage.getPlayer(uuid)` returns null, which after `ensurePlayerFile` is impossible unless storage itself is down — in which case failing closed is correct (don't hand out free kits if persistence is broken).

## Testing

- **Affected player** (no disk file, uncached): `/kit starter` → succeeds once, logs `[Kit] Self-healed missing PlayerFile for <name>`; second `/kit starter` → "already claimed"; `/kit daily` → works once, then shows cooldown. Verified on production.
- **Normal existing player**: no self-heal log (fast path hit), cooldowns work as before.
- **GUI open and claim**: same behavior as command path.

## Files changed

- `src/main/java/com/eliteessentials/services/KitService.java`
- `src/main/java/com/eliteessentials/storage/PlayerFileStorage.java`
- `src/main/java/com/eliteessentials/commands/hytale/HytaleKitCommand.java`
- `src/main/java/com/eliteessentials/gui/KitSelectionPage.java`

No constructor changes, no new dependencies, no `EliteEssentials.java` edits.

## Operational follow-up (for server admins)

After deploying, grep logs for:
- `Self-healed missing PlayerFile` — any hit is a Hytale join-path issue worth collecting
- `savePlayer called for uncached UUID` — should be empty in healthy operation